### PR TITLE
feat: switch from unmaintained neo-ltex to ltex-plus

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,16 +10,14 @@
 				"james-yu.latex-workshop",
 				"tecosaur.latex-utilities",
 				"yzhang.markdown-all-in-one",
-				"neo-ltex.ltex",
+				"ltex-plus.vscode-ltex-plus",
 				"DavidAnson.vscode-markdownlint"
 			],
 			"settings": {
 				"editor.wordWrap": "on",
 				"latex-workshop.intellisense.citation.backend": "biblatex",
 				// Fix pdf viewer jumping to top of document, see https://tex.stackexchange.com/a/706744
-				"latex-workshop.latex.watch.pdf.delay": 1000,
-				// Use pre-downloaded ltex-ls
-				"ltex.ltex-ls.path": "/usr/lib/ltex-ls-15.2.0"
+				"latex-workshop.latex.watch.pdf.delay": 1000
 			}
 		}
 	},

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /tmp/dockerwork
 # update texlive packages
 RUN tlmgr update --self --all
 
-# pre-download ltex-ls
-RUN wget -qO- https://github.com/valentjn/ltex-ls/releases/download/15.2.0/ltex-ls-15.2.0-linux-x64.tar.gz | \
-    tar -xz --strip-components=1
-RUN mv ltex-ls-15.2.0 /usr/lib
+# pre-download ltex-ls (Removed due to ltex+ having very frequent updates)
+# RUN wget -qO- https://github.com/valentjn/ltex-ls/releases/download/15.2.0/ltex-ls-15.2.0-linux-x64.tar.gz | \
+#     tar -xz --strip-components=1
+# RUN mv ltex-ls-15.2.0 /usr/lib
 
 # Cleanup
 RUN rm -rf /tmp/dockerwork


### PR DESCRIPTION
Switches to the maintained fork [ltex+](https://github.com/ltex-plus/vscode-ltex-plus) of ltex.